### PR TITLE
Remove collision copy and restore.

### DIFF
--- a/SA2-Debug-Mode/save-state.cpp
+++ b/SA2-Debug-Mode/save-state.cpp
@@ -54,7 +54,7 @@ void SaveStates::getPlayerInfo() {
 
 	memcpy(&this->slots[currentSaveState].charData.player, MainCharacter[0], sizeof(ObjectMaster));
 	memcpy(&this->slots[currentSaveState].charData.data, MainCharacter[0]->Data1.Entity, sizeof(EntityData1));
-	memcpy(&this->slots[currentSaveState].charData.col, MainCharacter[0]->Data1.Entity->Collision, sizeof(CollisionInfo));
+	//memcpy(&this->slots[currentSaveState].charData.col, MainCharacter[0]->Data1.Entity->Collision, sizeof(CollisionInfo));
 
 	SaveCartPointer();
 
@@ -207,7 +207,7 @@ void SaveStates::restorePlayerInfo() {
 	if (TimeTotal % 1 == 0) //wait 1 frame to re load collision
 	{
 		memcpy(MainCharacter[0]->Data1.Entity, &this->slots[currentSaveState].charData.data, sizeof(EntityData1));
-		memcpy(MainCharacter[0]->Data1.Entity->Collision, &this->slots[currentSaveState].charData.col, sizeof(CollisionInfo));
+		//memcpy(MainCharacter[0]->Data1.Entity->Collision, &this->slots[currentSaveState].charData.col, sizeof(CollisionInfo));
 	}
 
 	return;


### PR DESCRIPTION
I've spent basically all day testing on this and there doesn't seem to be any particularly good reason to care about restoring this collision object. On the other hand, it's the cause for most of the crashes I experience with DebugMode savestates as far as I can tell.

There's one super reproducible savestate crash that I found in Metal Harbor which was the motivation for this PR.

Reproduction:

1. Play through metal harbor as normal up until the 2 pullies section.
2. Go up the first pully as normal, then setup for second pully skip and set a savestate while there.
3. Perform second pully skip then proceed past the gap after the following loop.
4. While in the air, reload the savestate.
5. Enjoy the crash.

Alternatively watch repro vid: https://youtu.be/9fJ9dWR0dEg

This PR resolves this crash without causing any adverse effects that I can notice. It seems the main issue is this is a complex object that recursively points to itself (i.e. Node A points to Node B and Node B points to Node A etc) so the memcpy doesn't really do a good job of saving and restoring this data. On the other hand, this object (the CollisionInfo pointer within CollisionInfo) is almost always null so it usually doesn't matter, and hence why crashes are not super common.