### PR TITLE
Fix Eternal Engine Crash

### DIFF
--- a/SA2-Debug-Mode/save-state.cpp
+++ b/SA2-Debug-Mode/save-state.cpp
@@ -5,9 +5,9 @@ int currentSaveState = 0;
 SaveStates* SaveStates::instance = 0;
 SaveStates* obj1 = obj1->getInstance();
 bool canDisplayMSG = false;
-FunctionHook<void, EntityData1*, EntityData2*, CharObj2Base*, CharObj2Base*> MechEggman_chkDmg_h((intptr_t)0x742C10);
-FunctionHook<void, ObjectMaster*> GamePlayerMissed_h((intptr_t)GamePlayerMissed);
-static FunctionHook<void> Init_LandColMemory_h((intptr_t)0x47BB50);
+Trampoline* MechEggman_chkDmg_t = nullptr;
+Trampoline* GamePlayerMissed_t = nullptr;
+static Trampoline* Init_LandColMemory_t = nullptr;
 const char slot_count = 7;
 
 void SaveStates::getGameInfo() {
@@ -415,7 +415,8 @@ void __cdecl MechEggman_ChecksDamage_r(EntityData1* a1, EntityData2* a3, CharObj
 		}
 	}
 
-	MechEggman_chkDmg_h.Original(a1, a3, a4, a2);
+	FunctionPointer(void, original, (EntityData1 * a1, EntityData2 * a3, CharObj2Base * a4, CharObj2Base * a2), MechEggman_chkDmg_t->Target());
+	original(a1, a3, a4, a2);
 }
 
 //since object doesn't run when the pause menu is active, we manually allow the player to save when the game is paused.
@@ -435,7 +436,8 @@ void __cdecl GamePlayerMissed_r(ObjectMaster* obj) {
 		}
 	}
 
-	GamePlayerMissed_h.Original(obj);
+	ObjectFunc(origin, GamePlayerMissed_t->Target());
+	origin(obj);
 }
 
 void SaveStates::resetSaveFiles() {
@@ -449,11 +451,12 @@ void InitLandColMemory_r() {
 		obj1->resetSaveFiles();
 	}
 
-	Init_LandColMemory_h.Original();
+	VoidFunc(origin, Init_LandColMemory_t->Target());
+	origin();
 }
 
 void init_SaveState() {
-	MechEggman_chkDmg_h.Hook(MechEggman_ChecksDamage_r);
-	GamePlayerMissed_h.Hook(GamePlayerMissed_r);
-	Init_LandColMemory_h.Hook(InitLandColMemory_r);
+	MechEggman_chkDmg_t = new Trampoline((int)0x742C10, (int)0x742C17, MechEggman_ChecksDamage_r);
+	GamePlayerMissed_t = new Trampoline((int)GamePlayerMissed, (int)GamePlayerMissed + 0x5, GamePlayerMissed_r);
+	Init_LandColMemory_t = new Trampoline((int)0x47BB50, (int)0x47BB57, InitLandColMemory_r);
 }

--- a/SA2-Debug-Mode/save-state.cpp
+++ b/SA2-Debug-Mode/save-state.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "save-state.h"
 
-int currentSaveState = 0;
+uint8_t currentSaveState = 0;
 SaveStates* SaveStates::instance = 0;
 SaveStates* obj1 = obj1->getInstance();
 bool canDisplayMSG = false;
@@ -172,8 +172,8 @@ void SaveStates::restoreCameraInfo() {
 	CampastPosIDX = this->slots[currentSaveState].CameraUnit.camConstPastPosIDX;
 }
 
-int bannedLevel[9] = { LevelIDs_PyramidCave, LevelIDs_AquaticMine, LevelIDs_HiddenBase, LevelIDs_LostColony, LevelIDs_CosmicWall,
-LevelIDs_EggQuarters, LevelIDs_IronGate, LevelIDs_FinalChase, LevelIDs_FinalRush };
+int bannedLevel[10] = { LevelIDs_PyramidCave, LevelIDs_AquaticMine, LevelIDs_HiddenBase, LevelIDs_LostColony, LevelIDs_CosmicWall,
+LevelIDs_EggQuarters, LevelIDs_IronGate, LevelIDs_FinalChase, LevelIDs_FinalRush, LevelIDs_EternalEngine };
 ObjectFuncPtr bannedObj[2] = { (ObjectFuncPtr)0x6A79E0,(ObjectFuncPtr)0x6F7AF0 };
 
 bool bannedLvlException() {

--- a/SA2-Debug-Mode/stdafx.h
+++ b/SA2-Debug-Mode/stdafx.h
@@ -11,7 +11,6 @@
 #include "LandTableInfo.h"
 #include "ModelInfo.h"
 #include "AnimationFile.h"
-#include "FunctionHook.h"
 #include "Trampoline.h"
 #include "sa2-util.h"
 #include "mod.h"


### PR DESCRIPTION
Reverting the function hooks change, that didn't work.

More importantly, there's a really common crash that happens near the goal ring in Eternal Engine. From what I was able to tell it seems the culprit are that the bullets the goal ring room shoots at you are objects that get spawned in and quickly despawned when the bullet goes away, trying to restore them leads to crashes.

Save States are most commonly used in EE for learning bofa which includes practicing the landing at the end where you go into the goal ring room from the back and saving/loading states in this area tends to crash. So this PR adds EE to the restore object ban list.

Reproduction: Create a save state on the invisible floor near/behind the goal ring. Float down as slow as possible as if you were going to touch the goal ring but miss it on purpose and get too low or potentially even float down to the kill plane. Load the save state. This crash is inconsistent so it would happen every single time following these steps, presumably depending on the objects state for the gun bullets around the goal ring.

With this update I was unable to reproduce it anymore after various attempts.