### PR TITLE
Fix current save slot cycle clamping

### DIFF
--- a/SA2-Debug-Mode/save-state.cpp
+++ b/SA2-Debug-Mode/save-state.cpp
@@ -308,15 +308,14 @@ void SaveStates::changeSlot(Buttons input) {
 
 	if (input & Buttons_Up) {
 		currentSaveState++;
+		if (currentSaveState > slot_count)
+			currentSaveState = 0;
 	} else if (input & Buttons_Down) {
+		if (currentSaveState == 0)
+			currentSaveState = slot_count + 1;
+
 		currentSaveState--;
 	}
-
-	if (currentSaveState > slot_count)
-		currentSaveState = 0;
-
-	if (currentSaveState < 0)
-		currentSaveState = slot_count;
 
 	timerMessage = 60;
 	this->message = "Current Slot %d";


### PR DESCRIPTION
In the last commit I changed `currentSaveState` from int to `uint8_t` which is a better datatype for a small array's index counter but I forgot about the value clamp when you cycle up/down so because an unsigned int doesn't allow negative values you can't cycle down from 0 to 7 anymore. This should fix that to restore being able to go up from 7 to 0 and down from 0 to 7.