### PR TITLE
fix saved camera position array length

### DIFF
--- a/SA2-Debug-Mode/save-state.cpp
+++ b/SA2-Debug-Mode/save-state.cpp
@@ -84,7 +84,7 @@ void SaveStates::getCameraInfo() {
 	//cam struct and array (fix most of the random cam issues)
 	this->slots[currentSaveState].CameraUnit.PosRotBufferIndex = PosRotBufferIndex[0];
 
-	memcpy(&this->slots[currentSaveState].CameraUnit.camConstpastPos, (void*)camConstPastPos, 0xC000);
+	memcpy(&this->slots[currentSaveState].CameraUnit.camConstpastPos, (void*)camConstPastPos, 0xC00);
 	this->slots[currentSaveState].CameraUnit.camConstPastPosIDX = CampastPosIDX;
 }
 
@@ -168,7 +168,7 @@ void SaveStates::restorePlayerInfo() {
 void SaveStates::restoreCameraInfo() {
 	memcpy((void*)0x1dcff00, &this->slots[currentSaveState].CameraUnit.cameraBackup, 0x2518);
 	PosRotBufferIndex[0] = this->slots[currentSaveState].CameraUnit.PosRotBufferIndex;
-	memcpy((void*)camConstPastPos, &this->slots[currentSaveState].CameraUnit.camConstpastPos, 0xC000);
+	memcpy((void*)camConstPastPos, &this->slots[currentSaveState].CameraUnit.camConstpastPos, 0xC00 );
 	CampastPosIDX = this->slots[currentSaveState].CameraUnit.camConstPastPosIDX;
 }
 

--- a/SA2-Debug-Mode/save-state.h
+++ b/SA2-Debug-Mode/save-state.h
@@ -13,11 +13,11 @@ struct CharaStruct {
 };
 
 struct CameraUnit {
-    char cameraBackup[0x2518];
-    char cameraPastPosBackup[0xc000];
-    char cameraPastRotBackup[0xc000];
+    char cameraBackup[0x2518];  
+    char cameraPastPosBackup[0xc00];
+    char cameraPastRotBackup[0xc00];
     char PosRotBufferIndex;
-    char camConstpastPos[0xc000];
+    char camConstpastPos[0xc00];
     char camConstPastPosIDX;
 };
 


### PR DESCRIPTION
This should fix differences in camera when loading a state between this mod and onvars tool.  Onvar made a typo in the comment that incorrectly represented the length of the struct [here](https://github.com/Isaac-Lozano/OnVars-Tool/blob/f6b3b117fdf976eebfc9a0f02d216d17bf6725ec/src/sa2_structures.rs#L269) and added a 0.  2 lines below is the actual size of the struct. (0xC000 (current) vs 0xC00 (actual)).

