### PR TITLE
Fix building repo

### DIFF
--- a/SA2-Debug-Mode/FreeCam.cpp
+++ b/SA2-Debug-Mode/FreeCam.cpp
@@ -17,8 +17,6 @@ bool isGamePaused = false;
 bool isCheatDisableHud = false;
 bool isCheatDisableExtraHud = false;
 
-auto DoSomethingWithCam = GenerateUsercallWrapper<void (*)(int a1, int a2, int a3)>(noret, 0x4EBCD0, rEAX, rECX, rEDI);
-
 enum FreeCamModes
 {
 	Camera_None = 0,
@@ -207,15 +205,15 @@ void FreeCam_CheckInput()
 			SetCursorPos(w / 2, h / 2);
 
 			//Use Cam Event since the regular cam has issue with angle for some reason
-			SetCameraEvent(0, 20);
-			DoSomethingWithCam(*(int*)&CameraData.gap1AC[168], 0, 0);
+			RegisterCameraMode(0, 20);
+			SetAdjustMode(*(int*)&CameraData[0].currentCameraSlot, 0, 0);
 			*(float*)0x1DCFE1C = 1.0f; //Zoom Needed to make angle working
 			*(int*)0x1DCFDE0 = 3;
 			*(int*)0x1DCFDE4 = 0;
 			*(int*)0x1DCFDE8 = 0;
-			CamEventPos = CameraData.Position;
-			CamEventAngleY = CameraData.Rotation.y;
-			CamEventAngleZ = CameraData.Rotation.z;	
+			CamEventPos = CameraData[0].location.pos;
+			CamEventAngleY = CameraData[0].location.ang.y;
+			CamEventAngleZ = CameraData[0].location.ang.z;
 
 			ShowHud = 0;
 			HudSpecialEnabled = 0;
@@ -233,7 +231,9 @@ void FreeCam_CheckInput()
 
 			IsNotPauseHide = 1;
 			isGamePaused = false;
-			ResetCam(CameraData.gap1AC[168], 0);
+			// Modloader flipped the args for this func in
+			// d634b7d25bea4be297f071221098cfc9eef2b19a
+			ReleaseCamera(0, CameraData[0].currentCameraSlot);
 		}
 
 		delayCam = 35;

--- a/SA2-Debug-Mode/death-zones.cpp
+++ b/SA2-Debug-Mode/death-zones.cpp
@@ -41,8 +41,8 @@ void DeathZone_Display(ObjectMaster* obj)
 
 		njSetTexture(texlist_objtex_common);
 		njPushMatrix(_nj_current_matrix_ptr_);
-		njControl3D_Backup();
-		njControl3D_Add(NJD_CONTROL_3D_CONSTANT_MATERIAL | NJD_CONTROL_3D_ENABLE_ALPHA | NJD_CONTROL_3D_CONSTANT_ATTR);
+		SaveControl3D();
+		OnControl3D(NJD_CONTROL_3D_CONSTANT_MATERIAL | NJD_CONTROL_3D_ENABLE_ALPHA | NJD_CONTROL_3D_CONSTANT_ATTR);
 		SetMaterial(0.4f, 1.0f, 0, 0);
 
 		sub_42D340();
@@ -51,7 +51,7 @@ void DeathZone_Display(ObjectMaster* obj)
 			ProcessChunkModelsWithCallback(DZObj[i]->getmodel(), ProcessChunkModel);
 
 		njPopMatrix(1u);
-		njControl3D_Restore();
+		LoadControl3D();
 		ResetMaterial();
 	}
 }
@@ -80,9 +80,9 @@ void DeathZoneRender_Manager(ObjectMaster* obj)
 		}
 		break;
 	case 2:
-		if (++data->field_6 == 30)
+		if (++data->Timer == 30)
 		{
-			data->field_6 = 0;
+			data->Timer = 0;
 			data->Action--;
 		}
 		break;

--- a/SA2-Debug-Mode/debug-text.cpp
+++ b/SA2-Debug-Mode/debug-text.cpp
@@ -263,12 +263,12 @@ void DisplayCameraInfo()
 	DisplayDebugStringFormatted(NJM_LOCATION(3, 7 + texPosY), "- CAMERA INFO -");
 	SetDebugFontColor(0xFFBFBFBF);
 
-	DisplayDebugStringFormatted(NJM_LOCATION(3, 9 + texPosY), "POS X: %.2f", CameraData.Position.x);
-	DisplayDebugStringFormatted(NJM_LOCATION(3, 10 + texPosY), "POS Y: %.2f", CameraData.Position.y);
-	DisplayDebugStringFormatted(NJM_LOCATION(3, 11 + texPosY), "POS Z: %.2f", CameraData.Position.z);	
+	DisplayDebugStringFormatted(NJM_LOCATION(3, 9 + texPosY), "POS X: %.2f", CameraData[0].location.pos.x);
+	DisplayDebugStringFormatted(NJM_LOCATION(3, 10 + texPosY), "POS Y: %.2f", CameraData[0].location.pos.y);
+	DisplayDebugStringFormatted(NJM_LOCATION(3, 11 + texPosY), "POS Z: %.2f", CameraData[0].location.pos.z);
 	
-	DisplayDebugStringFormatted(NJM_LOCATION(3, 13 + texPosY), "ANG X: %d", (Uint16)CameraData.Rotation.x, (360.0f / 65535.0f) * (Uint16)CameraData.Rotation.x);
-	DisplayDebugStringFormatted(NJM_LOCATION(3, 14 + texPosY), "ANG Y: %d", (Uint16)CameraData.Rotation.y, (360.0f / 65535.0f) * (Uint16)CameraData.Rotation.y);
+	DisplayDebugStringFormatted(NJM_LOCATION(3, 13 + texPosY), "ANG X: %d", (Uint16)CameraData[0].location.ang.x, (360.0f / 65535.0f) * (Uint16)CameraData[0].location.ang.x);
+	DisplayDebugStringFormatted(NJM_LOCATION(3, 14 + texPosY), "ANG Y: %d", (Uint16)CameraData[0].location.ang.y, (360.0f / 65535.0f) * (Uint16)CameraData[0].location.ang.y);
 
 	DisplayDebugStringFormatted(NJM_LOCATION(3, 16 + texPosY), "FREECAM MODE: %d", FreeCamMode);
 

--- a/SA2-Debug-Mode/goalring.cpp
+++ b/SA2-Debug-Mode/goalring.cpp
@@ -45,7 +45,7 @@ void GetGoalRing()
 
 		if (CurrentObjectList->List[id].Function == GoalRing_Main)
 		{
-			CurrentObjectList->List[id].DistanceMaybe *= 120; //increase goal ring display distance
+			CurrentObjectList->List[id].Distance *= 120; //increase goal ring display distance
 
 			if (Set[i].XRot != 1 && MissionNum == 2) { //if it's a lost chao mission, don't take the regular goal ring pos
 				continue;

--- a/SA2-Debug-Mode/sa2-util.h
+++ b/SA2-Debug-Mode/sa2-util.h
@@ -48,10 +48,6 @@ DataPointer(float, flt_1DCFF3C, 0x1DCFF3C);
 FastcallFunctionPointer(void, CameraFollowCharacter, (int playID), 0x4EC770);
 DataPointer(char, cam_handle, 0x01DCFF00);
 
-DataPointer(NJS_VECTOR, CamEventPos, 0x1DCFE10);
-DataPointer(int, CamEventAngleZ, 0x1DCFDF8);
-DataPointer(int, CamEventAngleY, 0x1DCFDFC);
-
 DataPointer(char, ShowHud, 0x0174AFCC);
 DataPointer(int, dword_1A558BC, 0x1A558BC);
 DataPointer(int, dword_17472BC, 0x17472BC);
@@ -90,64 +86,6 @@ static inline void AddConstantAttr(int a1, int a2)
 
 
 VoidFunc(sub_42D340, 0x42D340);
-DataPointer(int, nj_constant_attr_and_, 0x01DEB6A8);
-DataPointer(int, nj_constant_attr_or_, 0x01DEB6A0);
 DataPointer(char, PauseDisabled, 0x0174AFD6);
 
 using Angle3 = Rotation;
-struct taskwk;
-
-struct c_colli_hit_info
-{
-	char my_num;
-	char hit_num;
-	unsigned __int16 flag;
-	taskwk* hit_twp;
-};
-
-struct CCL_INFO
-{
-	char kind;
-	char form;
-	char push;
-	char damage;
-	unsigned int attr;
-	NJS_POINT3 center;
-	float a;
-	float b;
-	float c;
-	float d;
-	int angx;
-	int angy;
-	int angz;
-};
-
-struct colliwk
-{
-	unsigned __int16 id;
-	__int16 nbHit;
-	unsigned __int16 flag;
-	unsigned __int16 nbInfo;
-	float colli_range;
-	CCL_INFO* info;
-	c_colli_hit_info hit_info[16];
-	NJS_POINT3 normal;
-	ObjectMaster* mytask;
-	__int16 my_num;
-	__int16 hit_num;
-	colliwk* hit_cwp;
-};
-
-struct taskwk
-{
-	char mode;
-	char smode;
-	char id;
-	char btimer;
-	__int16 flag;
-	unsigned __int16 wtimer;
-	Angle3 ang;
-	NJS_POINT3 pos;
-	NJS_POINT3 scl;
-	colliwk* cwp;
-};

--- a/SA2-Debug-Mode/save-state.cpp
+++ b/SA2-Debug-Mode/save-state.cpp
@@ -374,7 +374,7 @@ void SaveStateManager(ObjectMaster* obj) {
 		data->Action = CheckInputs;
 		break;
 	case CheckInputs:
-		data->field_6 = 0;
+		data->Timer = 0;
 		data->Index = 0;
 		data->NextAction = 0;
 		SavestatesCheckInput(obj);
@@ -389,7 +389,7 @@ void SaveStateManager(ObjectMaster* obj) {
 		break;
 	case SaveDelay:
 
-		if (++data->field_6 == 8) {
+		if (++data->Timer == 8) {
 			data->Action = CheckInputs;
 
 			if (!isFreeMov) {


### PR DESCRIPTION
commit 9b5233d7 reverted to an older version of the mod loader to fix a bug in FreeCam, but it didn't revert the submodule. This meant that the project wouldn't build from a fresh checkout.

This reverts the reversion, while maintaining the fix for FreeCam - the FreeCam bug was a result of the newer version of mod loader inverting the function arguments to the ReleaseCamera function when it got renamed from ResetCam